### PR TITLE
Implement a global role system for users

### DIFF
--- a/lib/raira/accounts.ex
+++ b/lib/raira/accounts.ex
@@ -93,6 +93,12 @@ defmodule Raira.Accounts do
     |> Repo.insert()
   end
 
+  def register_admin(attrs) do
+    %User{}
+    |> User.admin_changeset(attrs)
+    |> Repo.insert()
+  end
+
   ## Settings
 
   @doc """

--- a/lib/raira/accounts/user.ex
+++ b/lib/raira/accounts/user.ex
@@ -17,6 +17,7 @@ defmodule Raira.Accounts.User do
     field :username, :string
 
     field :hex_color, Raira.EctoTypes.HexColor
+    field :role, :string, default: "user"
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/raira/accounts/user.ex
+++ b/lib/raira/accounts/user.ex
@@ -22,9 +22,22 @@ defmodule Raira.Accounts.User do
     timestamps(type: :utc_datetime)
   end
 
+  # Public registration - No role casting
   def registration_changeset(user, attrs, opts \\ []) do
     user
     |> cast(attrs, [:email, :first_name, :last_name, :username, :password])
+    |> put_change(:role, "user") # Force role to "user"
+    |> unique_constraint(:username)
+    |> validate_username()
+    |> validate_password(opts)
+  end
+
+  # TODO: Write doc and use only admin registration
+  # Admin-only changeset - Can set roles
+  def admin_changeset(user, attrs, opts \\ []) do
+    user
+    |> cast(attrs, [:email, :first_name, :last_name, :username, :password, :role])
+    |> validate_inclusion(:role, ["admin", "user"])
     |> unique_constraint(:username)
     |> validate_username()
     |> validate_password(opts)

--- a/priv/repo/migrations/20251005092851_add_role_to_users.exs
+++ b/priv/repo/migrations/20251005092851_add_role_to_users.exs
@@ -1,0 +1,11 @@
+defmodule Raira.Repo.Migrations.AddRoleToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :role, :string, default: "user", null: false
+    end
+
+    create index(:users, [:role])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,7 +10,6 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias Raira.Repo
 alias Raira.Accounts
 
 admin_flname = "admin"
@@ -25,11 +24,12 @@ user_name = "user"
 
 case Accounts.get_user_by_email(admin_email) do
   nil ->
-    {:ok, _admin} = Accounts.register_user(%{
+    {:ok, _admin} = Accounts.register_admin(%{
       first_name: admin_flname,
       last_name: admin_flname,
       username: admin_name,
       email: admin_email,
+      role: "admin",
       password: password
     })
 


### PR DESCRIPTION
This pull request introduces role-based user management to the application. The main changes include adding a `role` field to the `users` table and supporting both regular and admin user registration with appropriate validations.

**Database and schema changes:**

* Added a `role` field to the `users` table with a default value of `"user"` and created an index on this field to optimize queries by role. (`priv/repo/migrations/20251005092851_add_role_to_users.exs`)
* Updated the `User` schema to include the `role` field, defaulting to `"user"`. (`lib/raira/accounts/user.ex`)

**User registration logic:**

* Added two changesets: `registration_changeset` for public registration (forces role to `"user"`), and `admin_changeset` for admin registration (allows setting `"admin"` or `"user"` roles, with validation). (`lib/raira/accounts/user.ex`)
* Implemented a new `register_admin/1` function to support admin user creation using the appropriate changeset. (`lib/raira/accounts.ex`)

**Seed data update:**

* Updated seed logic to use `register_admin/1` for creating the initial admin user, ensuring the role is set to `"admin"`. (`priv/repo/seeds.exs`)

These changes lay the foundation for role-based access control in the application.