### PR TITLE
Drawer side panel

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -197,3 +197,5 @@
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 
 /* This file is for your main application CSS */
+
+@import "./js_interop.css";

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -199,3 +199,4 @@
 /* This file is for your main application CSS */
 
 @import "./js_interop.css";
+@import "./tooltips.css";

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -199,4 +199,12 @@
 /* This file is for your main application CSS */
 
 @import "./js_interop.css";
+
+:root,
+[data-theme] {
+  --tooltip-bg: var(--color-neutral);            /* bubble background */
+  --tooltip-fg: var(--color-neutral-content);    /* bubble text */
+  --tooltip-radius: var(--radius-box, 0.5rem);   /* bubble radius */
+}
+
 @import "./tooltips.css";

--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -6,3 +6,50 @@ we hide/show certain elements. This way we don't have to engage the
 server in solely client-side operations.
 */
 
+
+/* Show/hide individual panes based on active content */
+[data-el-session] {
+  /* (already present rules)... */
+
+  /* Side panel */
+  &:not([data-js-side-panel-content]) [data-el-side-panel] {
+    @apply hidden;
+  }
+
+  /* add this line for others-list, mirroring the existing clients-list one */
+  &:not([data-js-side-panel-content="others-list"]) [data-el-others-list] {
+    @apply hidden;
+  }
+
+  /* hide the Messages pane unless it's selected */
+  &:not([data-js-side-panel-content="messages-list"]) [data-el-messages-list] {
+    @apply hidden;
+  }
+
+  /* (keep your existing lines) */
+  &:not([data-js-side-panel-content="outline"]) [data-el-outline],
+  &:not([data-js-side-panel-content="clients-list"]) [data-el-clients-list],
+  &:not([data-js-side-panel-content="secrets-list"]) [data-el-secrets-list],
+  &:not([data-js-side-panel-content="files-list"]) [data-el-files-list],
+  &:not([data-js-side-panel-content="runtime-info"]) [data-el-runtime-info],
+  &:not([data-js-side-panel-content="app-info"]) [data-el-app-info] {
+    @apply hidden;
+  }
+
+
+    /* highlight the Messages button when active */
+    &[data-js-side-panel-content="messages-list"] [data-el-messages-list-toggle] {
+      @apply text-gray-50 bg-gray-700;
+    }
+
+  /* active button styling (add the others-list line) */
+  &[data-js-side-panel-content="others-list"] [data-el-others-list-toggle],
+  &[data-js-side-panel-content="outline"] [data-el-outline-toggle],
+  &[data-js-side-panel-content="clients-list"] [data-el-clients-list-toggle],
+  &[data-js-side-panel-content="secrets-list"] [data-el-secrets-list-toggle],
+  &[data-js-side-panel-content="files-list"] [data-el-files-list-toggle],
+  &[data-js-side-panel-content="runtime-info"] [data-el-runtime-info-toggle],
+  &[data-js-side-panel-content="app-info"] [data-el-app-info-toggle] {
+    @apply text-gray-50 bg-gray-700;
+  }
+}

--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -6,12 +6,3 @@ we hide/show certain elements. This way we don't have to engage the
 server in solely client-side operations.
 */
 
-/* Hide clients list unless the session says it's active */
-[data-el-session]:not([data-js-side-panel-content="clients-list"]) [data-el-clients-list] {
-  display: none;
-}
-
-/* Optional: highlight the active button */
-[data-el-session][data-js-side-panel-content="clients-list"] [data-el-clients-list-toggle] {
-  @apply text-white bg-gray-700;
-}

--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -1,0 +1,17 @@
+/*
+Conditional elements display.
+
+Verious hooks and callbacks dynamically set attributes based on which
+we hide/show certain elements. This way we don't have to engage the
+server in solely client-side operations.
+*/
+
+/* Hide clients list unless the session says it's active */
+[data-el-session]:not([data-js-side-panel-content="clients-list"]) [data-el-clients-list] {
+  display: none;
+}
+
+/* Optional: highlight the active button */
+[data-el-session][data-js-side-panel-content="clients-list"] [data-el-clients-list-toggle] {
+  @apply text-white bg-gray-700;
+}

--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -34,8 +34,8 @@ Example usage:
   text-align: center;
   display: block;
   z-index: 100;
-  background-color: #1c273c;
-  color: #f0f5f9;
+  background-color: var(--tooltip-bg);
+  color: var(--tooltip-fg);
   font-size: 12px;
   font-weight: 500;
   border-radius: 4px;
@@ -44,6 +44,7 @@ Example usage:
   transition-property: visibility;
   transition-duration: 0s;
   transition-delay: 0s;
+  border-radius: var(--tooltip-radius);
 }
 
 /* Tooltip arrow */
@@ -55,7 +56,7 @@ Example usage:
   /* For the arrow we use the triangle trick: https://css-tricks.com/snippets/css/css-triangle/ */
   border-width: var(--arrow-size);
   border-style: solid;
-  border-color: #1c273c;
+  border-color: transparent; /* start transparent on all sides */
   visibility: hidden;
   transition-property: visibility;
   transition-duration: 0s;

--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -1,0 +1,162 @@
+/* Tooltips */
+
+/*
+Example usage:
+
+  <span class="tooltip top" data-tooltip="Delete">
+    ...
+  </span>
+*/
+
+/* Tooltip element wrapping the actual hoverable element */
+.tooltip {
+  position: relative;
+  display: flex;
+  --distance: 4px;
+  --arrow-size: 5px;
+  --arrow-side-offset: 10px;
+  --show-delay: 0.5s;
+}
+
+.tooltip.distant {
+  --distance: 28px;
+}
+
+.tooltip.distant-medium {
+  --distance: 14px;
+}
+
+/* Tooltip text */
+.tooltip:before {
+  position: absolute;
+  content: attr(data-tooltip);
+  white-space: pre;
+  text-align: center;
+  display: block;
+  z-index: 100;
+  background-color: #1c273c;
+  color: #f0f5f9;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 4px;
+  padding: 3px 12px;
+  visibility: hidden;
+  transition-property: visibility;
+  transition-duration: 0s;
+  transition-delay: 0s;
+}
+
+/* Tooltip arrow */
+.tooltip:after {
+  content: "";
+  position: absolute;
+  display: block;
+  z-index: 100;
+  /* For the arrow we use the triangle trick: https://css-tricks.com/snippets/css/css-triangle/ */
+  border-width: var(--arrow-size);
+  border-style: solid;
+  border-color: #1c273c;
+  visibility: hidden;
+  transition-property: visibility;
+  transition-duration: 0s;
+  transition-delay: 0s;
+}
+
+.tooltip:hover:before {
+  visibility: visible;
+  transition-delay: var(--show-delay);
+}
+
+.tooltip:hover:after {
+  visibility: visible;
+  transition-delay: var(--show-delay);
+}
+
+/*
+Note: we let the arrow and content overlap 1px,
+otherwise there's a tiny space between them.
+*/
+
+.tooltip.top:before {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, calc(1px - var(--arrow-size) - var(--distance)));
+}
+
+.tooltip.top-right:before {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(
+    calc(0px - var(--arrow-side-offset)),
+    calc(1px - var(--arrow-size) - var(--distance))
+  );
+}
+
+.tooltip.top:after,
+.tooltip.top-right:after {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, calc(0px - var(--distance)));
+
+  border-bottom: none;
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+
+.tooltip.bottom:before {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, calc(var(--arrow-size) - 1px + var(--distance)));
+}
+
+.tooltip.bottom-left:before {
+  top: 100%;
+  left: 50%;
+  transform: translate(
+    calc(-100% + var(--arrow-side-offset)),
+    calc(var(--arrow-size) - 1px + var(--distance))
+  );
+}
+
+.tooltip.bottom:after,
+.tooltip.bottom-left:after {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, var(--distance));
+
+  border-top: none;
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+
+.tooltip.right:before {
+  top: 50%;
+  left: 100%;
+  transform: translate(calc(var(--arrow-size) - 1px + var(--distance)), -50%);
+}
+
+.tooltip.right:after {
+  top: 50%;
+  left: 100%;
+  transform: translate(var(--distance), -50%);
+
+  border-left: none;
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+}
+
+.tooltip.left:before {
+  top: 50%;
+  right: 100%;
+  transform: translate(calc(1px - var(--arrow-size) - var(--distance)), -50%);
+}
+
+.tooltip.left:after {
+  top: 50%;
+  right: 100%;
+  transform: translate(calc(0px - var(--distance)), -50%);
+
+  border-right: none;
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+}

--- a/assets/js/hooks/index.js
+++ b/assets/js/hooks/index.js
@@ -1,6 +1,8 @@
 import UserForm from "./user_form";
+import Session from "./session";
 
 export default {
     // Not use UserForm anymore cause use sqlite collect user profile instead cookie on web
     //UserForm,
+    Session,
 }

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -1,13 +1,59 @@
 const Session = {
   mounted() {
-    const sidebarToggle = document.querySelector("[data-el-clients-list-toggle]");
-    const sidePanel = document.querySelector("[data-el-side-panel]");
+    // prevent double-binding on LV patches
+    if (this._wired) return;
+    this._wired = true;
 
-    if (sidebarToggle && sidePanel) {
-      sidebarToggle.addEventListener("click", () => {
-        sidePanel.classList.toggle("hidden");
-      });
+    const clientsBtn = this.getElement("clients-list-toggle");
+    const othersBtn  = this.getElement("others-list-toggle");
+    const messagesBtn = this.getElement("messages-list-toggle");
+
+    clientsBtn && clientsBtn.addEventListener("click", () =>
+      this.toggleClientsList()
+    );
+
+    othersBtn && othersBtn.addEventListener("click", () =>
+      this.toggleOthersList()
+    );
+
+    messagesBtn && messagesBtn.addEventListener("click", () =>
+      this.toggleMessagesList()
+    );
+  },
+
+  // --- toggles --------------------------------------------------------------
+
+  toggleClientsList(force = null) {
+    return this.toggleSidePanelContent("clients-list", force);
+  },
+
+  toggleOthersList(force = null) {
+    return this.toggleSidePanelContent("others-list", force);
+  },
+
+  toggleMessagesList(force = null) {
+    return this.toggleSidePanelContent("messages-list", force);
+  },
+
+  toggleSidePanelContent(name, force = null) {
+    const ATTR = "data-js-side-panel-content";
+    const current = this.el.getAttribute(ATTR);
+
+    // If clicking the same icon, close the panel; otherwise open/switch
+    const shouldOpen = force === null ? current !== name : !!force;
+
+    if (shouldOpen) {
+      this.el.setAttribute(ATTR, name);
+    } else {
+      this.el.removeAttribute(ATTR);
     }
+    return shouldOpen;
+  },
+
+  // --- helpers --------------------------------------------------------------
+
+  getElement(name) {
+    return this.el.querySelector(`[data-el-${name}]`);
   },
 };
 

--- a/assets/js/hooks/session.js
+++ b/assets/js/hooks/session.js
@@ -1,0 +1,14 @@
+const Session = {
+  mounted() {
+    const sidebarToggle = document.querySelector("[data-el-clients-list-toggle]");
+    const sidePanel = document.querySelector("[data-el-side-panel]");
+
+    if (sidebarToggle && sidePanel) {
+      sidebarToggle.addEventListener("click", () => {
+        sidePanel.classList.toggle("hidden");
+      });
+    }
+  },
+};
+
+export default Session;

--- a/lib/raira_web/components/layout_components.ex
+++ b/lib/raira_web/components/layout_components.ex
@@ -101,9 +101,21 @@ defmodule RairaWeb.LayoutComponents do
       />
 
       <.button_item
+        icon="hero-home"
+        label="Clients (so)"
+        button_attrs={["data-el-clients-list-toggle": true]}
+      />
+
+      <.button_item
         icon="hero-user"
         label="Connected users (su)"
-        button_attrs={["data-el-clients-list-toggle": true]}
+        button_attrs={["data-el-others-list-toggle": true]}
+      />
+
+      <.button_item
+        icon="hero-chat-bubble-oval-left-ellipsis"
+        label="Clients (so)"
+        button_attrs={["data-el-messages-list-toggle": true]}
       />
       <!--
 
@@ -163,7 +175,13 @@ defmodule RairaWeb.LayoutComponents do
         link_attrs={["data-btn-show-shortcuts": true]}
       />
       -->
+      <div class="grow"></div>
 
+      <.button_item
+        icon="hero-camera"
+        label="Outline (so)"
+        button_attrs={["data-el-outline-toggle": true]}
+      />
       <span class="tooltip right distant" data-tooltip="User profile">
         <button
           class="text-gray-400 rounded-xl h-8 w-8 flex items-center justify-center mt-2 group"
@@ -188,6 +206,8 @@ defmodule RairaWeb.LayoutComponents do
       data-el-side-panel
     >
       <.clients_list />
+      <.others_list />
+      <.messages_list />
     </div>
     """
   end
@@ -358,6 +378,52 @@ defmodule RairaWeb.LayoutComponents do
       <div class="flex items-center justify-between space-x-4 -mt-1">
         <h3 class="uppercase text-sm font-semibold text-gray-500">
           Users
+        </h3>
+        <span class="flex items-center px-2 py-1 space-x-2 text-sm bg-gray-200 rounded-lg">
+          <span class="inline-flex w-3 h-3 bg-green-600 rounded-full"></span>
+          <!--
+          <span>{length(@data_view.clients)} connected</span>
+          -->
+
+          <!-- Example: <span>3 connected</span> -->
+        </span>
+      </div>
+      <div class="flex flex-col mt-5 space-y-4">
+      <!-- client list items -->
+      </div>
+    </div>
+    """
+  end
+
+  defp others_list(assigns) do
+    ~H"""
+    <div class="flex flex-col grow" data-el-others-list>
+      <div class="flex items-center justify-between space-x-4 -mt-1">
+        <h3 class="uppercase text-sm font-semibold text-gray-500">
+          Others
+        </h3>
+        <span class="flex items-center px-2 py-1 space-x-2 text-sm bg-gray-200 rounded-lg">
+          <span class="inline-flex w-3 h-3 bg-green-600 rounded-full"></span>
+          <!--
+          <span>{length(@data_view.clients)} connected</span>
+          -->
+
+          <!-- Example: <span>3 connected</span> -->
+        </span>
+      </div>
+      <div class="flex flex-col mt-5 space-y-4">
+      <!-- client list items -->
+      </div>
+    </div>
+    """
+  end
+
+  defp messages_list(assigns) do
+    ~H"""
+    <div class="flex flex-col grow" data-el-messages-list>
+      <div class="flex items-center justify-between space-x-4 -mt-1">
+        <h3 class="uppercase text-sm font-semibold text-gray-500">
+          Messages
         </h3>
         <span class="flex items-center px-2 py-1 space-x-2 text-sm bg-gray-200 rounded-lg">
           <span class="inline-flex w-3 h-3 bg-green-600 rounded-full"></span>

--- a/lib/raira_web/components/layout_components.ex
+++ b/lib/raira_web/components/layout_components.ex
@@ -15,7 +15,7 @@ defmodule RairaWeb.LayoutComponents do
     ~H"""
     <div class="flex grow h-full">
       <div class="absolute md:static h-full z-[600]">
-        <.sidebar current_page={@current_page} current_user={@current_user}/>
+        <.sidebar current_page={@current_page} current_user={@current_user} />
       </div>
 
       <div class="grow overflow-y-auto">
@@ -31,17 +31,164 @@ defmodule RairaWeb.LayoutComponents do
             >
             </button>
           </div>
-
         </div>
 
         {render_slot(@inner_block)}
       </div>
     </div>
 
-
     <.current_user_modal current_user={@current_user} />
     <p>Current page: {@current_page}</p>
     <p>Current username: {@current_user.username}</p>
+    """
+  end
+
+  @doc """
+  The layout used in the non-sessios pages.
+  """
+  attr :current_page, :string, required: true
+  attr :current_user, Raira.Accounts.User, required: true
+  slot :inner_block, required: true
+
+  def drawer_layout(assigns) do
+    ~H"""
+    <div class="flex grow h-full" data-el-session data-js-side-panel-content="clients-list">
+      <.drawer_sidebar current_page={@current_page} current_user={@current_user} />
+      <.drawer_side_panel />
+
+      <div class="grow overflow-y-auto">
+        <div class="md:hidden sticky flex items-center justify-between h-14 px-4 top-0 left-0 z-[500] bg-white border-b border-gray-200">
+          <div class="pt-1 text-xl text-gray-400 hover:text-gray-600 focus:text-gray-600">
+            <button
+              data-el-toggle-sidebar
+              aria-label="show sidebar"
+              phx-click={
+                JS.remove_class("hidden", to: "[data-el-sidebar]")
+                |> JS.toggle(to: "[data-el-toggle-sidebar]")
+              }
+            >
+            </button>
+          </div>
+        </div>
+
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+
+    <.current_user_modal current_user={@current_user} />
+    """
+  end
+
+  defp drawer_sidebar(assigns) do
+    ~H"""
+    <nav
+      class="w-16 flex flex-col items-center px-3 py-1 space-y-2 sm:space-y-3 sm:py-5 bg-gray-900"
+      aria-label="sidebar"
+      data-el-sidebar
+    >
+      <span>
+        <.link navigate={~p"/"} aria-label="go to homepage">
+          <img src={~p"/images/logo.png"} height="40" width="40" alt="" />
+        </.link>
+      </span>
+
+      <%!-- Local functionality --%>
+
+      <.button_item
+        icon="hero-home"
+        label="Outline (so)"
+        button_attrs={["data-el-outline-toggle": true]}
+      />
+
+      <.button_item
+        icon="hero-user"
+        label="Connected users (su)"
+        button_attrs={["data-el-clients-list-toggle": true]}
+      />
+      <!--
+
+      <div class="relative">
+        <.button_item
+          icon="cpu-line"
+          label="Runtime settings (sr)"
+          button_attrs={["data-el-runtime-info-toggle": true]}
+        />
+        <div
+          :if={@runtime_connected_nodes != []}
+          data-el-runtime-indicator
+          class={[
+            "absolute w-[12px] h-[12px] border-gray-900 border-2 rounded-full right-1.5 top-1.5 pointer-events-none",
+            "bg-blue-500"
+          ]}
+        />
+      </div>
+      -->
+
+      <%!-- Hub functionality --%>
+
+    <!--
+      <.button_item
+        icon="lock-password-line"
+        label="Secrets (ss)"
+        button_attrs={["data-el-secrets-list-toggle": true]}
+      />
+
+      <.button_item
+        icon="folder-open-fill"
+        label="Files (sf)"
+        button_attrs={["data-el-files-list-toggle": true]}
+      />
+
+      <.button_item
+        icon="rocket-line"
+        label="App settings (sa)"
+        button_attrs={["data-el-app-info-toggle": true]}
+      />
+
+      <div class="grow"></div>
+
+      <.link_item
+        icon="delete-bin-6-fill"
+        label="Bin (sb)"
+        path={~p"/sessions/#{@session.id}/bin"}
+        active={@live_action == :bin}
+        link_attrs={["data-btn-show-bin": true]}
+      />
+
+      <.link_item
+        icon="keyboard-box-fill"
+        label="Keyboard shortcuts (?)"
+        path={~p"/sessions/#{@session.id}/shortcuts"}
+        active={@live_action == :shortcuts}
+        link_attrs={["data-btn-show-shortcuts": true]}
+      />
+      -->
+
+      <span class="tooltip right distant" data-tooltip="User profile">
+        <button
+          class="text-gray-400 rounded-xl h-8 w-8 flex items-center justify-center mt-2 group"
+          aria_label="user profile"
+          phx-click={show_current_user_modal()}
+        >
+          <.user_avatar
+            user={@current_user}
+            class="w-8 h-8 group-hover:ring-white group-hover:ring-2"
+            text_class="text-xs"
+          />
+        </button>
+      </span>
+    </nav>
+    """
+  end
+
+  defp drawer_side_panel(assigns) do
+    ~H"""
+    <div
+      class="flex flex-col h-full w-full max-w-xs absolute z-30 top-0 left-[64px] overflow-y-auto shadow-xl md:static md:shadow-none bg-gray-50 border-r border-gray-100 px-6 pt-16 md:py-8"
+      data-el-side-panel
+    >
+      <.clients_list />
+    </div>
     """
   end
 
@@ -66,7 +213,6 @@ defmodule RairaWeb.LayoutComponents do
               </.link>
 
               <span class="text-gray-300 text-xs font-normal font-sans mx-2.5 pt-3 cursor-default">
-
                 v{Raira.Config.app_version()}
               </span>
             </div>
@@ -98,7 +244,7 @@ defmodule RairaWeb.LayoutComponents do
             class="mt-6 flex items-center group border-l-4 border-transparent"
             aria_label="user profile"
           >
-          <div class="w-[56px] flex justify-center">
+            <div class="w-[56px] flex justify-center">
               <.user_avatar
                 user={@current_user}
                 class="w-8 h-8 group-hover:ring-white group-hover:ring-2"
@@ -191,4 +337,41 @@ defmodule RairaWeb.LayoutComponents do
 
   defp sidebar_link_border_color(to, current) when to == current, do: "border-white"
   defp sidebar_link_border_color(_to, _current), do: "border-transparent"
+
+  defp button_item(assigns) do
+    ~H"""
+    <span class="tooltip right distant" data-tooltip={@label}>
+      <button
+        class="text-2xl text-gray-400 hover:text-gray-50 focus:text-gray-50 rounded-xl h-10 w-10 flex items-center justify-center"
+        aria-label={@label}
+        {@button_attrs}
+      >
+        <.icon name={@icon} />
+      </button>
+    </span>
+    """
+  end
+
+  defp clients_list(assigns) do
+    ~H"""
+    <div class="flex flex-col grow" data-el-clients-list>
+      <div class="flex items-center justify-between space-x-4 -mt-1">
+        <h3 class="uppercase text-sm font-semibold text-gray-500">
+          Users
+        </h3>
+        <span class="flex items-center px-2 py-1 space-x-2 text-sm bg-gray-200 rounded-lg">
+          <span class="inline-flex w-3 h-3 bg-green-600 rounded-full"></span>
+          <!--
+          <span>{length(@data_view.clients)} connected</span>
+          -->
+        </span>
+      </div>
+      <div class="flex flex-col mt-5 space-y-4">
+        <!--
+
+        -->
+      </div>
+    </div>
+    """
+  end
 end

--- a/lib/raira_web/components/layout_components.ex
+++ b/lib/raira_web/components/layout_components.ex
@@ -52,7 +52,7 @@ defmodule RairaWeb.LayoutComponents do
 
   def drawer_layout(assigns) do
     ~H"""
-    <div class="flex grow h-full" data-el-session data-js-side-panel-content="clients-list">
+    <div class="flex grow h-full" data-el-session phx-hook="Session" id="session-root">
       <.drawer_sidebar current_page={@current_page} current_user={@current_user} />
       <.drawer_side_panel />
 
@@ -364,12 +364,12 @@ defmodule RairaWeb.LayoutComponents do
           <!--
           <span>{length(@data_view.clients)} connected</span>
           -->
+
+          <!-- Example: <span>3 connected</span> -->
         </span>
       </div>
       <div class="flex flex-col mt-5 space-y-4">
-        <!--
-
-        -->
+      <!-- client list items -->
       </div>
     </div>
     """

--- a/lib/raira_web/live/home_live.ex
+++ b/lib/raira_web/live/home_live.ex
@@ -19,7 +19,7 @@ defmodule RairaWeb.HomeLive do
             <.button color="gray" outlined navigate={~p"/open/storage"}>
               Open
             </.button>
-            <.button color="blue" patch={~p"/new"}>
+            <.button color="blue" patch={~p"/project"}>
               <.icon name="hero-add-line" />
               <span>New notebook</span>
             </.button>

--- a/lib/raira_web/live/project_test_live.ex
+++ b/lib/raira_web/live/project_test_live.ex
@@ -1,0 +1,24 @@
+defmodule RairaWeb.ProjectTestLive do
+  alias RairaWeb.LayoutComponents
+  use RairaWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    user = socket.assigns |> IO.inspect(label: "TEST")
+    {:ok, assign(socket, self_path: ~p"/", page_title: "Project test")}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <LayoutComponents.drawer_layout current_page={~p"/"} current_user={@current_scope.user}>
+      <div class="p-4 md:px-12 md:py-6 max-w-screen-lg mx-auto">
+        <div class="flex flex-row space-y-0 items-center pb-4 justify-between">
+          <LayoutComponents.title text="Project" />
+          <p>TEST</p>
+        </div>
+      </div>
+    </LayoutComponents.drawer_layout>
+    """
+  end
+end

--- a/lib/raira_web/router.ex
+++ b/lib/raira_web/router.ex
@@ -61,6 +61,7 @@ defmodule RairaWeb.Router do
 
       live "/", HomeLive, :page
       live "/settings", SettingsLive, :page
+      live "/project", ProjectTestLive, :page
     end
 
     post "/users/update-password", UserSessionController, :update_password


### PR DESCRIPTION
This pull request introduces a new "drawer" sidebar and side panel layout for non-session pages, refactors the CSS and JS to support dynamic side panel toggling, and adds a test project page using the new layout. The main changes include new reusable layout components, enhancements to client-side interactivity via hooks and CSS, and improved tooltip styling.

**Layout and UI Components:**

* Added `drawer_layout`, `drawer_sidebar`, and `drawer_side_panel` components to `layout_components.ex` for a new sidebar and side panel structure, including reusable button and list components for clients, others, and messages. [[1]](diffhunk://#diff-a9181addc001ce8df5ba24551fe53d6bc7a68a24fe2fe00e4a3d5f8d18b9da02L34-R214) [[2]](diffhunk://#diff-a9181addc001ce8df5ba24551fe53d6bc7a68a24fe2fe00e4a3d5f8d18b9da02R360-R442)
* Created a new live view `project_test_live.ex` that uses the drawer layout for demonstration and testing.
* Registered the `/project` route to serve the new test page.

**Client-Side Interactivity:**

* Added a new `Session` hook in `session.js` to handle toggling of sidebar panels for clients, others, and messages, enabling dynamic UI updates without server round-trips. [[1]](diffhunk://#diff-c7ff9cf11033b9682dd0afe25c589bc5adbdc606c1becc9b50594f8181a77a03R1-R60) [[2]](diffhunk://#diff-99b4b4b6f23ef067282c2399557d613eeac0f9d0e076111f4ed2f7a73931cda2R2-R7)

**CSS and Styling:**

* Refactored `app.css` to import new CSS files for JS interop and tooltips, and defined root-level tooltip variables.
* Added `js_interop.css` for conditional display of side panel elements and active button highlighting based on client-side state.
* Introduced `tooltips.css` for improved tooltip styling and positioning, including support for different directions and delays.

**Minor UX Improvements:**

* Updated the "New notebook" button in the home page to route to `/project` instead of `/new`.

---

**Change references:**  
[[1]](diffhunk://#diff-a9181addc001ce8df5ba24551fe53d6bc7a68a24fe2fe00e4a3d5f8d18b9da02L34-R214) [[2]](diffhunk://#diff-a9181addc001ce8df5ba24551fe53d6bc7a68a24fe2fe00e4a3d5f8d18b9da02R360-R442) [[3]](diffhunk://#diff-90e69fba0809ff6ef890e1a91d789aa90ff2556fb56a09148761e3f2e868d721R1-R24) [[4]](diffhunk://#diff-6f19216215c80f1f84b1d7374a1ee3deee05befc60fa1c0a8efa2f152c67a8a1R64) [[5]](diffhunk://#diff-c7ff9cf11033b9682dd0afe25c589bc5adbdc606c1becc9b50594f8181a77a03R1-R60) [[6]](diffhunk://#diff-99b4b4b6f23ef067282c2399557d613eeac0f9d0e076111f4ed2f7a73931cda2R2-R7) [[7]](diffhunk://#diff-c34c53250169f2b561ed4ffba912d24712d569dbfe297a95c6b1c940afce7880R200-R210) [[8]](diffhunk://#diff-2669a277d0cb86e66000bdafba6e6ad1b6f86d643ac22f3e8086d1ed65fba18dR1-R55) [[9]](diffhunk://#diff-a0cacd5671b8710d78787798d040c5ef01fc3deb1b0c2938337b3d10e018c687R1-R163) [[10]](diffhunk://#diff-138afc3034a5ba386a02e33db390830443bde791d2a1fb3c375b8ca857697558L22-R22)