### PR TITLE
Improve filter out the current user when manage users page

### DIFF
--- a/lib/raira/accounts/user.ex
+++ b/lib/raira/accounts/user.ex
@@ -36,6 +36,8 @@ defmodule Raira.Accounts.User do
     # Force role to "user"
     |> put_change(:role, "user")
     |> unique_constraint(:username)
+    # FIXME: Always assign a random hex color for hex_color
+    |> put_change(:hex_color, Raira.EctoTypes.HexColor.random())
     |> validate_username()
     |> validate_password(opts)
   end
@@ -47,6 +49,8 @@ defmodule Raira.Accounts.User do
     |> cast(attrs, [:email, :first_name, :last_name, :username, :password, :role])
     |> validate_inclusion(:role, ["admin", "user"])
     |> unique_constraint(:username)
+    # FIXME: Always assign a random hex color for hex_color
+    |> put_change(:hex_color, Raira.EctoTypes.HexColor.random())
     |> validate_username()
     |> validate_password(opts)
   end

--- a/lib/raira_web/live/user_live/index.ex
+++ b/lib/raira_web/live/user_live/index.ex
@@ -280,6 +280,6 @@ defmodule RairaWeb.UserLive.Index do
   end
 
   defp list_users(current_scope) do
-    Accounts.list_users(current_scope)
+    Accounts.list_manageable_users(current_scope.user.id)
   end
 end


### PR DESCRIPTION
This pull request updates the user listing functionality to allow for more flexible and clear ways to retrieve users, particularly when excluding the current user from results. The changes introduce new helper functions in `Raira.Accounts` for listing users with or without the current user, and update the user listing in the LiveView to use these new helpers.

**User listing enhancements:**

* Added `list_users/1` to support an `:exclude_user_id` option, allowing queries that exclude a specific user from the results.
* Introduced `list_users_except_current/1` and `list_manageable_users/1` helpers to easily list all users except the current one, improving code clarity and reusability.

**LiveView update:**

* Updated `RairaWeb.UserLive.Index` to use `Accounts.list_manageable_users/1` for retrieving the user list, ensuring the current user is excluded from the list.

**Documentation improvements:**

* Added detailed module documentation and usage examples for the new user listing functions, improving maintainability and developer experience.