### PR TITLE
Fix flash group duplicate

### DIFF
--- a/lib/raira_web/components/core_components.ex
+++ b/lib/raira_web/components/core_components.ex
@@ -67,7 +67,7 @@ defmodule RairaWeb.CoreComponents do
     -->
     <div
       :if={msg = Phoenix.Flash.get(@flash, @kind)}
-      phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
+      phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide_flash()}
       role="alert"
       class="toast toast-top toast-end z-50"
       {@rest}
@@ -94,6 +94,15 @@ defmodule RairaWeb.CoreComponents do
       </div>
     </div>
     """
+  end
+
+  defp hide_flash(js \\ %JS{}) do
+    JS.hide(js,
+      time: 200,
+      transition:
+        {"transition-all ease-in duration-200", "opacity-100 translate-y-0 sm:scale-100",
+         "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"}
+    )
   end
 
   @doc """

--- a/lib/raira_web/components/layouts.ex
+++ b/lib/raira_web/components/layouts.ex
@@ -68,7 +68,9 @@ defmodule RairaWeb.Layouts do
       </div>
     </main>
 
+    <!--
     <.flash_group flash={@flash} />
+    -->
     """
   end
 


### PR DESCRIPTION

**### It still got duplicate.**
This pull request introduces a small refactor to how flash messages are hidden in the UI and temporarily comments out the rendering of the flash group in the layout. The main change is the extraction of a `hide_flash/1` helper for consistent transition effects when dismissing flash messages.

**Flash message behavior improvements:**

* Extracted a new private helper function `hide_flash/1` in `core_components.ex` to encapsulate the transition and timing logic for hiding flash messages, ensuring consistent UI behavior.
* Updated the flash message dismissal logic to use the new `hide_flash/1` helper instead of an inline `hide` call, improving maintainability and readability.

**Layout adjustments:**

* Commented out the `<.flash_group>` component in the main layout, which temporarily disables the display of grouped flash messages.
