### PR TITLE
Feature/project crud

### DIFF
--- a/lib/raira/projects.ex
+++ b/lib/raira/projects.ex
@@ -1,0 +1,147 @@
+defmodule Raira.Projects do
+  @moduledoc """
+  The Projects context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Raira.Repo
+
+  alias Raira.Projects.Project
+  alias Raira.Accounts.Scope
+
+  @doc """
+  Subscribes to scoped notifications about any project changes.
+
+  The broadcasted messages match the pattern:
+
+    * {:created, %Project{}}
+    * {:updated, %Project{}}
+    * {:deleted, %Project{}}
+
+  """
+  def subscribe_projects(%Scope{} = scope) do
+    key = scope.user.id
+
+    Phoenix.PubSub.subscribe(Raira.PubSub, "user:#{key}:projects")
+  end
+
+  defp broadcast_project(%Scope{} = scope, message) do
+    key = scope.user.id
+
+    Phoenix.PubSub.broadcast(Raira.PubSub, "user:#{key}:projects", message)
+  end
+
+  @doc """
+  Returns the list of projects.
+
+  ## Examples
+
+      iex> list_projects(scope)
+      [%Project{}, ...]
+
+  """
+  def list_projects(%Scope{} = scope) do
+    Repo.all_by(Project, user_id: scope.user.id)
+  end
+
+  @doc """
+  Gets a single project.
+
+  Raises `Ecto.NoResultsError` if the Project does not exist.
+
+  ## Examples
+
+      iex> get_project!(scope, 123)
+      %Project{}
+
+      iex> get_project!(scope, 456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_project!(%Scope{} = scope, id) do
+    Repo.get_by!(Project, id: id, user_id: scope.user.id)
+  end
+
+  @doc """
+  Creates a project.
+
+  ## Examples
+
+      iex> create_project(scope, %{field: value})
+      {:ok, %Project{}}
+
+      iex> create_project(scope, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_project(%Scope{} = scope, attrs) do
+    with {:ok, project = %Project{}} <-
+           %Project{}
+           |> Project.changeset(attrs, scope)
+           |> Repo.insert() do
+      broadcast_project(scope, {:created, project})
+      {:ok, project}
+    end
+  end
+
+  @doc """
+  Updates a project.
+
+  ## Examples
+
+      iex> update_project(scope, project, %{field: new_value})
+      {:ok, %Project{}}
+
+      iex> update_project(scope, project, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_project(%Scope{} = scope, %Project{} = project, attrs) do
+    true = project.user_id == scope.user.id
+
+    with {:ok, project = %Project{}} <-
+           project
+           |> Project.changeset(attrs, scope)
+           |> Repo.update() do
+      broadcast_project(scope, {:updated, project})
+      {:ok, project}
+    end
+  end
+
+  @doc """
+  Deletes a project.
+
+  ## Examples
+
+      iex> delete_project(scope, project)
+      {:ok, %Project{}}
+
+      iex> delete_project(scope, project)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_project(%Scope{} = scope, %Project{} = project) do
+    true = project.user_id == scope.user.id
+
+    with {:ok, project = %Project{}} <-
+           Repo.delete(project) do
+      broadcast_project(scope, {:deleted, project})
+      {:ok, project}
+    end
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking project changes.
+
+  ## Examples
+
+      iex> change_project(scope, project)
+      %Ecto.Changeset{data: %Project{}}
+
+  """
+  def change_project(%Scope{} = scope, %Project{} = project, attrs \\ %{}) do
+    true = project.user_id == scope.user.id
+
+    Project.changeset(project, attrs, scope)
+  end
+end

--- a/lib/raira/projects/project.ex
+++ b/lib/raira/projects/project.ex
@@ -1,0 +1,23 @@
+defmodule Raira.Projects.Project do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "projects" do
+    field :name, :string
+    field :description, :string
+    field :status, :string
+    field :user_id, :binary_id
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(project, attrs, user_scope) do
+    project
+    |> cast(attrs, [:name, :description, :status])
+    |> validate_required([:name, :description, :status])
+    |> put_change(:user_id, user_scope.user.id)
+  end
+end

--- a/lib/raira/projects/project.ex
+++ b/lib/raira/projects/project.ex
@@ -7,7 +7,8 @@ defmodule Raira.Projects.Project do
   schema "projects" do
     field :name, :string
     field :description, :string
-    field :status, :string
+    #field :status, :string
+    field :status, Ecto.Enum, values: [:active, :archived, :completed], default: :active
     field :user_id, :binary_id
 
     timestamps(type: :utc_datetime)

--- a/lib/raira_web/components/core_components.ex
+++ b/lib/raira_web/components/core_components.ex
@@ -688,4 +688,23 @@ defmodule RairaWeb.CoreComponents do
     """
   end
 
+  slot :inner_block, required: true
+  slot :actions
+
+  def no_entries(assigns) do
+    ~H"""
+    <div class="p-5 flex space-x-4 items-center border border-gray-200 rounded-lg">
+      <div>
+        <.icon name="ri-windy-line" class="text-gray-400 text-xl" />
+      </div>
+      <div class="grow flex items-center justify-between">
+        <div class="text-gray-600">
+          {render_slot(@inner_block)}
+        </div>
+        {render_slot(@actions)}
+      </div>
+    </div>
+    """
+  end
+
 end

--- a/lib/raira_web/live/home_live.ex
+++ b/lib/raira_web/live/home_live.ex
@@ -1,11 +1,23 @@
 defmodule RairaWeb.HomeLive do
+  alias Raira.Projects
   alias RairaWeb.LayoutComponents
   use RairaWeb, :live_view
 
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns |> IO.inspect(label: "TEST")
-    {:ok, assign(socket, self_path: ~p"/", page_title: "Home")}
+
+    projects = [
+      %{id: "TEST1", name: "SandClock", description: "Time tracking app", status: :active},
+      %{id: "TEST2", name: "TrackMDay", description: "Track your day with simplicity", status: :active},
+      %{id: "TEST3", name: "POSify", description: "POS system for cafes", status: :archived},
+      %{id: "TEST4", name: "GoothStack", description: "Go + Elixir + Haskell experiment", status: :pending},
+      %{id: "TEST5", name: "KitchenView", description: "Monitor kitchen orders", status: :active}
+    ]
+
+    projects_empty = []
+
+    {:ok, assign(socket, self_path: ~p"/", page_title: "Home", projects: projects)}
   end
 
   @impl true
@@ -24,6 +36,66 @@ defmodule RairaWeb.HomeLive do
               <span>New notebook</span>
             </.button>
           </div>
+        </div>
+
+        <div id="starred-notebooks" role="region" aria-label="starred notebooks">
+          <div class="my-4 flex items-center md:items-end justify-between">
+            <h2 class="uppercase font-semibold text-gray-500 text-sm md:text-base">
+              Starred notebooks
+            </h2>
+            <button
+              class="flex items-center text-blue-600"
+              phx-click="toggle_starred_expanded"
+            >
+              <span class="font-semibold">Show more</span>
+            </button>
+          </div>
+          <%= if @projects == [] do %>
+            Empty
+          <% else %>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5" role="group">
+            <%= for {item, idx} <- Enum.with_index(@projects) do %>
+                   <div
+                  class="flex flex-col p-4 border bg-gray-50 border-gray-300 rounded-lg"
+              >
+                <div class="flex items-center justify-between">
+                  <span class="tooltip top" >
+                    <span class="text-gray-800 font-medium">
+                      {item.name}
+                    </span>
+                  </span>
+              <!--
+                  {@card_icon && render_slot(@card_icon, {info, idx})}
+              -->
+                </div>
+                <div class="mt-1 flex-grow text-gray-600 text-sm">
+              <!--
+                  {@added_at_label}
+
+                  {LivebookWeb.HTMLHelpers.format_datetime_relatively(info.added_at)} ago
+              -->
+                </div>
+                <div class="mt-2 flex space-x-6">
+                  <button
+                    class="text-blue-600 font-medium"
+                    phx-click={JS.push("fork", value: %{idx: idx})}
+                  >
+                    Fork
+                  </button>
+                </div>
+              </div>
+              <% end %>
+
+            </div>
+          <% end %>
+        </div>
+
+        <div id="running-sessions" class="py-20 mb-32" role="region" aria-label="running sessions">
+          <.live_component
+            module={RairaWeb.HomeLive.ProjectListComponent}
+            id="projects-list"
+            projects={@projects}
+          />
         </div>
       </div>
     </LayoutComponents.layout>

--- a/lib/raira_web/live/home_live.ex
+++ b/lib/raira_web/live/home_live.ex
@@ -31,7 +31,7 @@ defmodule RairaWeb.HomeLive do
             <.button color="gray" outlined navigate={~p"/open/storage"}>
               Open
             </.button>
-            <.button color="blue" patch={~p"/project"}>
+            <.button color="blue" patch={~p"/projects/new"}>
               <.icon name="ri-add-line" />
               <span>New notebook</span>
             </.button>

--- a/lib/raira_web/live/home_live/project_list_component.ex
+++ b/lib/raira_web/live/home_live/project_list_component.ex
@@ -1,0 +1,98 @@
+defmodule RairaWeb.HomeLive.ProjectListComponent do
+  use RairaWeb, :live_component
+
+  @impl true
+  def mount(socket) do
+    {:ok, assign(socket, order_by: "date")}
+  end
+
+  @impl true
+  def update(socket) do
+    {:ok, assign(socket, order_by: "date")}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <form id="bulk-action-form" phx-submit="bulk_action" phx-target={@myself}>
+      <div class="mb-4 flex items-center md:items-end justify-between">
+        <h2 class="uppercase font-semibold text-gray-500 text-sm md:text-base">
+          Running projects ({length(@projects)})
+        </h2>
+      </div>
+      <.session_list
+        projects={@projects}
+        myself={@myself}
+      />
+    </form>
+    """
+  end
+
+  defp session_list(%{projects: []} = assigns) do
+    ~H"""
+    <.no_entries>
+      You do not have any running sessions.
+      <%= if true do %>
+        <br />
+        Looking for unsaved notebooks? <.link
+          class="font-semibold"
+          navigate={~p"/open/storage?autosave=true"}
+          phx-no-format
+        >Browse them here</.link>.
+      <% end %>
+    </.no_entries>
+    """
+  end
+
+  defp session_list(assigns) do
+    ~H"""
+    <div class="flex flex-col" role="group" aria-label="running sessions list">
+      <ul class="list bg-base-100">
+        <li
+          :for={project <- @projects}
+          class="list-row"
+          data-test-session-id={project.id}
+        >
+          <div>
+            <img
+              class="size-10 rounded-box"
+              src="https://img.daisyui.com/images/profile/demo/1@94.webp"
+            />
+          </div>
+          <div>
+            <div>{project.name}</div>
+            <div class="text-xs uppercase font-semibold opacity-60">Remaining Reason</div>
+          </div>
+          <button class="btn btn-square btn-ghost">
+            <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <g
+                stroke-linejoin="round"
+                stroke-linecap="round"
+                stroke-width="2"
+                fill="none"
+                stroke="currentColor"
+              >
+                <path d="M6 3L20 12 6 21 6 3z"></path>
+              </g>
+            </svg>
+          </button>
+          <button class="btn btn-square btn-ghost">
+            <svg class="size-[1.2em]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <g
+                stroke-linejoin="round"
+                stroke-linecap="round"
+                stroke-width="2"
+                fill="none"
+                stroke="currentColor"
+              >
+                <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z">
+                </path>
+              </g>
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </div>
+    """
+  end
+end

--- a/lib/raira_web/live/project_live/form.ex
+++ b/lib/raira_web/live/project_live/form.ex
@@ -1,5 +1,6 @@
 defmodule RairaWeb.ProjectLive.Form do
   use RairaWeb, :live_view
+  alias RairaWeb.LayoutComponents
 
   alias Raira.Projects
   alias Raira.Projects.Project
@@ -7,6 +8,31 @@ defmodule RairaWeb.ProjectLive.Form do
   @impl true
   def render(assigns) do
     ~H"""
+    <LayoutComponents.drawer_layout current_page={~p"/"} current_user={@current_scope.user}>
+      <div class="relative w-full max-w-screen-lg px-4 sm:pl-8 sm:pr-16 md:pl-16 pt-4 sm:py-5 mx-auto">
+        <div class="flex flex-row space-y-0 items-center pb-4 justify-between">
+          <LayoutComponents.title text="Project" />
+        </div>
+
+          <.form for={@form} id="project-form" phx-change="validate" phx-submit="save">
+            <.input field={@form[:name]} type="text" label="Name" />
+            <.input field={@form[:description]} type="textarea" label="Description" />
+            <.input
+              field={@form[:status]}
+              type="select"
+              label="Status"
+              options={status_options()}
+              prompt="Choose a status"
+            />
+            <footer>
+              <.button phx-disable-with="Saving..." variant="primary">Save Project</.button>
+              <.button navigate={return_path(@current_scope, @return_to, @project)}>Cancel</.button>
+            </footer>
+          </.form>
+      </div>
+    </LayoutComponents.drawer_layout>
+
+    <!--
     <Layouts.app flash={@flash} current_scope={@current_scope}>
       <.header>
         {@page_title}
@@ -16,9 +42,7 @@ defmodule RairaWeb.ProjectLive.Form do
       <.form for={@form} id="project-form" phx-change="validate" phx-submit="save">
         <.input field={@form[:name]} type="text" label="Name" />
         <.input field={@form[:description]} type="textarea" label="Description" />
-        <!--
         <.input field={@form[:status]} type="text" label="Status" />
-        -->
         <.input
           field={@form[:status]}
           type="select"
@@ -32,6 +56,7 @@ defmodule RairaWeb.ProjectLive.Form do
         </footer>
       </.form>
     </Layouts.app>
+    -->
     """
   end
 
@@ -74,7 +99,13 @@ defmodule RairaWeb.ProjectLive.Form do
 
   @impl true
   def handle_event("validate", %{"project" => project_params}, socket) do
-    changeset = Projects.change_project(socket.assigns.current_scope, socket.assigns.project, project_params)
+    changeset =
+      Projects.change_project(
+        socket.assigns.current_scope,
+        socket.assigns.project,
+        project_params
+      )
+
     {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
   end
 
@@ -83,7 +114,11 @@ defmodule RairaWeb.ProjectLive.Form do
   end
 
   defp save_project(socket, :edit, project_params) do
-    case Projects.update_project(socket.assigns.current_scope, socket.assigns.project, project_params) do
+    case Projects.update_project(
+           socket.assigns.current_scope,
+           socket.assigns.project,
+           project_params
+         ) do
       {:ok, project} ->
         {:noreply,
          socket

--- a/lib/raira_web/live/project_live/form.ex
+++ b/lib/raira_web/live/project_live/form.ex
@@ -16,7 +16,16 @@ defmodule RairaWeb.ProjectLive.Form do
       <.form for={@form} id="project-form" phx-change="validate" phx-submit="save">
         <.input field={@form[:name]} type="text" label="Name" />
         <.input field={@form[:description]} type="textarea" label="Description" />
+        <!--
         <.input field={@form[:status]} type="text" label="Status" />
+        -->
+        <.input
+          field={@form[:status]}
+          type="select"
+          label="Status"
+          options={status_options()}
+          prompt="Choose a status"
+        />
         <footer>
           <.button phx-disable-with="Saving..." variant="primary">Save Project</.button>
           <.button navigate={return_path(@current_scope, @return_to, @project)}>Cancel</.button>
@@ -24,6 +33,14 @@ defmodule RairaWeb.ProjectLive.Form do
       </.form>
     </Layouts.app>
     """
+  end
+
+  defp status_options do
+    [
+      {"Active", :active},
+      {"Archived", :archived},
+      {"Completed", :completed}
+    ]
   end
 
   @impl true

--- a/lib/raira_web/live/project_live/form.ex
+++ b/lib/raira_web/live/project_live/form.ex
@@ -1,0 +1,100 @@
+defmodule RairaWeb.ProjectLive.Form do
+  use RairaWeb, :live_view
+
+  alias Raira.Projects
+  alias Raira.Projects.Project
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope}>
+      <.header>
+        {@page_title}
+        <:subtitle>Use this form to manage project records in your database.</:subtitle>
+      </.header>
+
+      <.form for={@form} id="project-form" phx-change="validate" phx-submit="save">
+        <.input field={@form[:name]} type="text" label="Name" />
+        <.input field={@form[:description]} type="textarea" label="Description" />
+        <.input field={@form[:status]} type="text" label="Status" />
+        <footer>
+          <.button phx-disable-with="Saving..." variant="primary">Save Project</.button>
+          <.button navigate={return_path(@current_scope, @return_to, @project)}>Cancel</.button>
+        </footer>
+      </.form>
+    </Layouts.app>
+    """
+  end
+
+  @impl true
+  def mount(params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:return_to, return_to(params["return_to"]))
+     |> apply_action(socket.assigns.live_action, params)}
+  end
+
+  defp return_to("show"), do: "show"
+  defp return_to(_), do: "index"
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    project = Projects.get_project!(socket.assigns.current_scope, id)
+
+    socket
+    |> assign(:page_title, "Edit Project")
+    |> assign(:project, project)
+    |> assign(:form, to_form(Projects.change_project(socket.assigns.current_scope, project)))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    project = %Project{user_id: socket.assigns.current_scope.user.id}
+
+    socket
+    |> assign(:page_title, "New Project")
+    |> assign(:project, project)
+    |> assign(:form, to_form(Projects.change_project(socket.assigns.current_scope, project)))
+  end
+
+  @impl true
+  def handle_event("validate", %{"project" => project_params}, socket) do
+    changeset = Projects.change_project(socket.assigns.current_scope, socket.assigns.project, project_params)
+    {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
+  end
+
+  def handle_event("save", %{"project" => project_params}, socket) do
+    save_project(socket, socket.assigns.live_action, project_params)
+  end
+
+  defp save_project(socket, :edit, project_params) do
+    case Projects.update_project(socket.assigns.current_scope, socket.assigns.project, project_params) do
+      {:ok, project} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Project updated successfully")
+         |> push_navigate(
+           to: return_path(socket.assigns.current_scope, socket.assigns.return_to, project)
+         )}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp save_project(socket, :new, project_params) do
+    case Projects.create_project(socket.assigns.current_scope, project_params) do
+      {:ok, project} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Project created successfully")
+         |> push_navigate(
+           to: return_path(socket.assigns.current_scope, socket.assigns.return_to, project)
+         )}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  defp return_path(_scope, "index", _project), do: ~p"/projects"
+  defp return_path(_scope, "show", project), do: ~p"/projects/#{project}"
+end

--- a/lib/raira_web/live/project_live/index.ex
+++ b/lib/raira_web/live/project_live/index.ex
@@ -1,0 +1,75 @@
+defmodule RairaWeb.ProjectLive.Index do
+  use RairaWeb, :live_view
+
+  alias Raira.Projects
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope}>
+      <.header>
+        Listing Projects
+        <:actions>
+          <.button variant="primary" navigate={~p"/projects/new"}>
+            <.icon name="ri-plus" /> New Project
+          </.button>
+        </:actions>
+      </.header>
+
+      <.table
+        id="projects"
+        rows={@streams.projects}
+        row_click={fn {_id, project} -> JS.navigate(~p"/projects/#{project}") end}
+      >
+        <:col :let={{_id, project}} label="Name">{project.name}</:col>
+        <:col :let={{_id, project}} label="Description">{project.description}</:col>
+        <:col :let={{_id, project}} label="Status">{project.status}</:col>
+        <:action :let={{_id, project}}>
+          <div class="sr-only">
+            <.link navigate={~p"/projects/#{project}"}>Show</.link>
+          </div>
+          <.link navigate={~p"/projects/#{project}/edit"}>Edit</.link>
+        </:action>
+        <:action :let={{id, project}}>
+          <.link
+            phx-click={JS.push("delete", value: %{id: project.id}) |> hide("##{id}")}
+            data-confirm="Are you sure?"
+          >
+            Delete
+          </.link>
+        </:action>
+      </.table>
+    </Layouts.app>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Projects.subscribe_projects(socket.assigns.current_scope)
+    end
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Listing Projects")
+     |> stream(:projects, list_projects(socket.assigns.current_scope))}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    project = Projects.get_project!(socket.assigns.current_scope, id)
+    {:ok, _} = Projects.delete_project(socket.assigns.current_scope, project)
+
+    {:noreply, stream_delete(socket, :projects, project)}
+  end
+
+  @impl true
+  def handle_info({type, %Raira.Projects.Project{}}, socket)
+      when type in [:created, :updated, :deleted] do
+    {:noreply, stream(socket, :projects, list_projects(socket.assigns.current_scope), reset: true)}
+  end
+
+  defp list_projects(current_scope) do
+    Projects.list_projects(current_scope)
+  end
+end

--- a/lib/raira_web/live/project_live/index.ex
+++ b/lib/raira_web/live/project_live/index.ex
@@ -11,7 +11,7 @@ defmodule RairaWeb.ProjectLive.Index do
         Listing Projects
         <:actions>
           <.button variant="primary" navigate={~p"/projects/new"}>
-            <.icon name="ri-plus" /> New Project
+            <.icon name="ri-add-line" /> New Project
           </.button>
         </:actions>
       </.header>

--- a/lib/raira_web/live/project_live/show.ex
+++ b/lib/raira_web/live/project_live/show.ex
@@ -1,0 +1,66 @@
+defmodule RairaWeb.ProjectLive.Show do
+  use RairaWeb, :live_view
+
+  alias Raira.Projects
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope}>
+      <.header>
+        Project {@project.id}
+        <:subtitle>This is a project record from your database.</:subtitle>
+        <:actions>
+          <.button navigate={~p"/projects"}>
+            <.icon name="hero-arrow-left" />
+          </.button>
+          <.button variant="primary" navigate={~p"/projects/#{@project}/edit?return_to=show"}>
+            <.icon name="hero-pencil-square" /> Edit project
+          </.button>
+        </:actions>
+      </.header>
+
+      <.list>
+        <:item title="Name">{@project.name}</:item>
+        <:item title="Description">{@project.description}</:item>
+        <:item title="Status">{@project.status}</:item>
+      </.list>
+    </Layouts.app>
+    """
+  end
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    if connected?(socket) do
+      Projects.subscribe_projects(socket.assigns.current_scope)
+    end
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Show Project")
+     |> assign(:project, Projects.get_project!(socket.assigns.current_scope, id))}
+  end
+
+  @impl true
+  def handle_info(
+        {:updated, %Raira.Projects.Project{id: id} = project},
+        %{assigns: %{project: %{id: id}}} = socket
+      ) do
+    {:noreply, assign(socket, :project, project)}
+  end
+
+  def handle_info(
+        {:deleted, %Raira.Projects.Project{id: id}},
+        %{assigns: %{project: %{id: id}}} = socket
+      ) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "The current project was deleted.")
+     |> push_navigate(to: ~p"/projects")}
+  end
+
+  def handle_info({type, %Raira.Projects.Project{}}, socket)
+      when type in [:created, :updated, :deleted] do
+    {:noreply, socket}
+  end
+end

--- a/lib/raira_web/live/project_live/show.ex
+++ b/lib/raira_web/live/project_live/show.ex
@@ -12,10 +12,10 @@ defmodule RairaWeb.ProjectLive.Show do
         <:subtitle>This is a project record from your database.</:subtitle>
         <:actions>
           <.button navigate={~p"/projects"}>
-            <.icon name="hero-arrow-left" />
+            <.icon name="ri-arrow-go-back-line" class="h-4 w-4" />
           </.button>
           <.button variant="primary" navigate={~p"/projects/#{@project}/edit?return_to=show"}>
-            <.icon name="hero-pencil-square" /> Edit project
+            <.icon name="ri-edit-line" class="h-4 w-4" /> Edit project
           </.button>
         </:actions>
       </.header>

--- a/lib/raira_web/router.ex
+++ b/lib/raira_web/router.ex
@@ -71,6 +71,10 @@ defmodule RairaWeb.Router do
       #live "/users/new", UserLive.Form, :new
       #live "/users/:id", UserLive.Show, :show
       #live "/users/:id/edit", UserLive.Form, :edit
+      live "/projects", ProjectLive.Index, :index
+      live "/projects/new", ProjectLive.Form, :new
+      live "/projects/:id", ProjectLive.Show, :show
+      live "/projects/:id/edit", ProjectLive.Form, :edit
     end
 
     post "/users/update-password", UserSessionController, :update_password

--- a/priv/repo/migrations/20251029160036_create_projects.exs
+++ b/priv/repo/migrations/20251029160036_create_projects.exs
@@ -1,0 +1,17 @@
+defmodule Raira.Repo.Migrations.CreateProjects do
+  use Ecto.Migration
+
+  def change do
+    create table(:projects, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :description, :text
+      add :status, :string
+      add :user_id, references(:users, type: :binary_id, on_delete: :delete_all)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:projects, [:user_id])
+  end
+end

--- a/test/raira/projects_test.exs
+++ b/test/raira/projects_test.exs
@@ -1,0 +1,95 @@
+defmodule Raira.ProjectsTest do
+  use Raira.DataCase
+
+  alias Raira.Projects
+
+  describe "projects" do
+    alias Raira.Projects.Project
+
+    import Raira.AccountsFixtures, only: [user_scope_fixture: 0]
+    import Raira.ProjectsFixtures
+
+    @invalid_attrs %{name: nil, status: nil, description: nil}
+
+    test "list_projects/1 returns all scoped projects" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      project = project_fixture(scope)
+      other_project = project_fixture(other_scope)
+      assert Projects.list_projects(scope) == [project]
+      assert Projects.list_projects(other_scope) == [other_project]
+    end
+
+    test "get_project!/2 returns the project with given id" do
+      scope = user_scope_fixture()
+      project = project_fixture(scope)
+      other_scope = user_scope_fixture()
+      assert Projects.get_project!(scope, project.id) == project
+      assert_raise Ecto.NoResultsError, fn -> Projects.get_project!(other_scope, project.id) end
+    end
+
+    test "create_project/2 with valid data creates a project" do
+      valid_attrs = %{name: "some name", status: "some status", description: "some description"}
+      scope = user_scope_fixture()
+
+      assert {:ok, %Project{} = project} = Projects.create_project(scope, valid_attrs)
+      assert project.name == "some name"
+      assert project.status == "some status"
+      assert project.description == "some description"
+      assert project.user_id == scope.user.id
+    end
+
+    test "create_project/2 with invalid data returns error changeset" do
+      scope = user_scope_fixture()
+      assert {:error, %Ecto.Changeset{}} = Projects.create_project(scope, @invalid_attrs)
+    end
+
+    test "update_project/3 with valid data updates the project" do
+      scope = user_scope_fixture()
+      project = project_fixture(scope)
+      update_attrs = %{name: "some updated name", status: "some updated status", description: "some updated description"}
+
+      assert {:ok, %Project{} = project} = Projects.update_project(scope, project, update_attrs)
+      assert project.name == "some updated name"
+      assert project.status == "some updated status"
+      assert project.description == "some updated description"
+    end
+
+    test "update_project/3 with invalid scope raises" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      project = project_fixture(scope)
+
+      assert_raise MatchError, fn ->
+        Projects.update_project(other_scope, project, %{})
+      end
+    end
+
+    test "update_project/3 with invalid data returns error changeset" do
+      scope = user_scope_fixture()
+      project = project_fixture(scope)
+      assert {:error, %Ecto.Changeset{}} = Projects.update_project(scope, project, @invalid_attrs)
+      assert project == Projects.get_project!(scope, project.id)
+    end
+
+    test "delete_project/2 deletes the project" do
+      scope = user_scope_fixture()
+      project = project_fixture(scope)
+      assert {:ok, %Project{}} = Projects.delete_project(scope, project)
+      assert_raise Ecto.NoResultsError, fn -> Projects.get_project!(scope, project.id) end
+    end
+
+    test "delete_project/2 with invalid scope raises" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      project = project_fixture(scope)
+      assert_raise MatchError, fn -> Projects.delete_project(other_scope, project) end
+    end
+
+    test "change_project/2 returns a project changeset" do
+      scope = user_scope_fixture()
+      project = project_fixture(scope)
+      assert %Ecto.Changeset{} = Projects.change_project(scope, project)
+    end
+  end
+end

--- a/test/raira_web/live/project_live_test.exs
+++ b/test/raira_web/live/project_live_test.exs
@@ -1,0 +1,125 @@
+defmodule RairaWeb.ProjectLiveTest do
+  use RairaWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Raira.ProjectsFixtures
+
+  @create_attrs %{name: "some name", status: "some status", description: "some description"}
+  @update_attrs %{name: "some updated name", status: "some updated status", description: "some updated description"}
+  @invalid_attrs %{name: nil, status: nil, description: nil}
+
+  setup :register_and_log_in_user
+
+  defp create_project(%{scope: scope}) do
+    project = project_fixture(scope)
+
+    %{project: project}
+  end
+
+  describe "Index" do
+    setup [:create_project]
+
+    test "lists all projects", %{conn: conn, project: project} do
+      {:ok, _index_live, html} = live(conn, ~p"/projects")
+
+      assert html =~ "Listing Projects"
+      assert html =~ project.name
+    end
+
+    test "saves new project", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/projects")
+
+      assert {:ok, form_live, _} =
+               index_live
+               |> element("a", "New Project")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/projects/new")
+
+      assert render(form_live) =~ "New Project"
+
+      assert form_live
+             |> form("#project-form", project: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert {:ok, index_live, _html} =
+               form_live
+               |> form("#project-form", project: @create_attrs)
+               |> render_submit()
+               |> follow_redirect(conn, ~p"/projects")
+
+      html = render(index_live)
+      assert html =~ "Project created successfully"
+      assert html =~ "some name"
+    end
+
+    test "updates project in listing", %{conn: conn, project: project} do
+      {:ok, index_live, _html} = live(conn, ~p"/projects")
+
+      assert {:ok, form_live, _html} =
+               index_live
+               |> element("#projects-#{project.id} a", "Edit")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/projects/#{project}/edit")
+
+      assert render(form_live) =~ "Edit Project"
+
+      assert form_live
+             |> form("#project-form", project: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert {:ok, index_live, _html} =
+               form_live
+               |> form("#project-form", project: @update_attrs)
+               |> render_submit()
+               |> follow_redirect(conn, ~p"/projects")
+
+      html = render(index_live)
+      assert html =~ "Project updated successfully"
+      assert html =~ "some updated name"
+    end
+
+    test "deletes project in listing", %{conn: conn, project: project} do
+      {:ok, index_live, _html} = live(conn, ~p"/projects")
+
+      assert index_live |> element("#projects-#{project.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#projects-#{project.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_project]
+
+    test "displays project", %{conn: conn, project: project} do
+      {:ok, _show_live, html} = live(conn, ~p"/projects/#{project}")
+
+      assert html =~ "Show Project"
+      assert html =~ project.name
+    end
+
+    test "updates project and returns to show", %{conn: conn, project: project} do
+      {:ok, show_live, _html} = live(conn, ~p"/projects/#{project}")
+
+      assert {:ok, form_live, _} =
+               show_live
+               |> element("a", "Edit")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/projects/#{project}/edit?return_to=show")
+
+      assert render(form_live) =~ "Edit Project"
+
+      assert form_live
+             |> form("#project-form", project: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert {:ok, show_live, _html} =
+               form_live
+               |> form("#project-form", project: @update_attrs)
+               |> render_submit()
+               |> follow_redirect(conn, ~p"/projects/#{project}")
+
+      html = render(show_live)
+      assert html =~ "Project updated successfully"
+      assert html =~ "some updated name"
+    end
+  end
+end

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule Raira.ProjectsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Raira.Projects` context.
+  """
+
+  @doc """
+  Generate a project.
+  """
+  def project_fixture(scope, attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        description: "some description",
+        name: "some name",
+        status: "some status"
+      })
+
+    {:ok, project} = Raira.Projects.create_project(scope, attrs)
+    project
+  end
+end


### PR DESCRIPTION
This pull request introduces a full-featured "Projects" context to the application, providing end-to-end CRUD (Create, Read, Update, Delete) functionality for user-scoped projects. It includes database schema, Ecto context and schema modules, LiveView components for listing, showing, and editing projects, and updates to the router to expose the new features. Additionally, new UI components are introduced to support empty states and project lists.

The most important changes are:

**Backend: Projects Context and Schema**
- Added a new `Raira.Projects` context with user-scoped CRUD operations, PubSub notifications for project changes, and integration with the Repo.
- Created the `Raira.Projects.Project` Ecto schema, including fields for `name`, `description`, `status` (with enum values), and `user_id`, along with a changeset function that enforces user scoping.

**Database Migration**
- Added a migration to create the `projects` table with appropriate fields, foreign key to users, and an index on `user_id`.

**LiveView Components and UI**
- Implemented LiveView modules for listing (`ProjectLive.Index`), showing (`ProjectLive.Show`), and creating/editing (`ProjectLive.Form`) projects, each with user-scoped data loading and PubSub updates for real-time UI changes. [[1]](diffhunk://#diff-34bb61e5149920bcb6d918a351148e6f5194276098b8fa808e0b21c0f4144103R1-R75) [[2]](diffhunk://#diff-909640a4b1605b07e83df2748325b558c586784055e49fbce498fc0d13612c92R1-R66) [[3]](diffhunk://#diff-91dd05da66a32fea31a94cc150e9c7f5a145929b203fcf747f2a375613aee746R1-R152)
- Added a new `ProjectListComponent` for displaying running projects and handling empty states, and a reusable `no_entries` UI component for consistent empty state messaging. [[1]](diffhunk://#diff-daaa70969d4935fdee95585ef814518ce66a08d2594d08c7709e67f3e84edd1bR1-R98) [[2]](diffhunk://#diff-32860b76dcfe00778ebaf2a895a8a87977b5316ff8a82ad043476a9b47dda4d7R691-R709)

**Routing**
- Updated the router to add routes for all project-related LiveViews (`/projects`, `/projects/new`, `/projects/:id`, `/projects/:id/edit`).

**Home Page Integration**
- Modified the home page LiveView to display a list of projects and integrate the new project creation flow. [[1]](diffhunk://#diff-138afc3034a5ba386a02e33db390830443bde791d2a1fb3c375b8ca857697558R2-R20) [[2]](diffhunk://#diff-138afc3034a5ba386a02e33db390830443bde791d2a1fb3c375b8ca857697558L22-R99)

These changes collectively establish a robust, user-scoped project management feature set within the application.